### PR TITLE
scrapeshell doesn't work with IPython 0.11

### DIFF
--- a/scrapelib.py
+++ b/scrapelib.py
@@ -660,10 +660,14 @@ def urlopen(url):
 
 def scrapeshell():
     try:
-        from IPython.Shell import IPShellEmbed
+        from IPython import embed
     except ImportError:
-        print 'scrapeshell requires ipython'
-        return
+        try:
+            from IPython.Shell import IPShellEmbed
+            embed = IPShellEmbed()
+        except ImportError:
+            print 'scrapeshell requires ipython'
+            return
     try:
         import argparse
     except ImportError:
@@ -704,4 +708,4 @@ def scrapeshell():
         print 'doc: `lxml HTML element`'
     import sys
     sys.argv = []
-    IPShellEmbed()()
+    embed()


### PR DESCRIPTION
I just stumbled across scrapeshell and tried to use it, only to get an error that I must have iPython installed. I do, however, so I did a little hunting.

I found this closed IPython ticket describing the change to embedding. 
https://github.com/ipython/ipython/issues/286

Knowing very little about all this, I mucked around and made this patch, which seems to work with both IPython 0.11 and IPython 0.9 (which I chose arbitrarily, but which I verified used the older syntax)
