### PR TITLE
test.py: return exit code to shell on failure

### DIFF
--- a/test.py
+++ b/test.py
@@ -393,5 +393,7 @@ if __name__ == '__main__':
     process = Process(target=run_server)
     process.start()
     time.sleep(0.1)
-    unittest.main(exit=False)
-    process.terminate()
+    try:
+        unittest.main()
+    finally:
+        process.terminate()


### PR DESCRIPTION
This change helps downstream packagers make the package build fail if a test fails.
