### PR TITLE
Urlretrieve now bypasses urlopen 

### DIFF
--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -337,7 +337,7 @@ class Scraper(CachingSession, ThrottledSession, RetrySession):
             a :class:`Response` object that can be used to inspect the
             response headers.
         """
-        result = self.request(method, url, data=body, **kwargs) #self.urlopen(url, method, body, **kwargs)
+        result = self.request(method, url, data=body, **kwargs) 
 
         if not filename:
             fd, filename = tempfile.mkstemp(dir=dir)


### PR DESCRIPTION
When retrieving large files that should be streamed directly to a file object (via urlretrieve) the response was being routed through the ResultStr class, which called the text() function on the response object. This forces a readthrough of the entire file to try and guess the encoding (via the chardet library) that is not performant on files larger than even a few MB, such as PDFs. Updated urlretrieve to bypass urlopen and use the request function instead. 
