### PR TITLE
added code attribute to response obj in urlretrieve

### DIFF
--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -338,6 +338,7 @@ class Scraper(CachingSession, ThrottledSession, RetrySession):
             response headers.
         """
         result = self.request(method, url, data=body, **kwargs) 
+        result.code = result.status_code #backwards compat
 
         if not filename:
             fd, filename = tempfile.mkstemp(dir=dir)


### PR DESCRIPTION
Forgot to run the tests in my last PR. Added the code attribute back to the response object and the tests now pass. 
