### PR TITLE
Add request param to allow SSL cipherlist to be amended

### DIFF
--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -534,6 +534,17 @@ class Scraper(CachingSession):
     ) -> CacheResponse:
         _log.info("{} - {!r}".format(method.upper(), url))
 
+        # allow modification of SSL ciphers list to accommodate misconfigured servers
+        # for example 'HIGH:!DH:!aNULL' to bypass "dh key too small" error
+        # https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small
+        if ciphers_list_addition:
+            requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ciphers_list_addition
+            try:
+                requests.packages.urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST += ciphers_list_addition
+            except AttributeError:
+                # no pyopenssl support used / needed / available
+                pass
+
         # apply global timeout
         if not timeout:
             timeout = self.timeout


### PR DESCRIPTION
The Florida legislature website is configured poorly and as a result I can't fetch PDFs for text extraction :) Simply setting the `verify` kwarg to `False` didn't seem to do anything.

Solution here seems to work (https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small)