### PR TITLE
Fix mypy errors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -502,21 +502,21 @@ pyyaml = "*"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "six"
@@ -926,8 +926,8 @@ pyyaml-env-tag = [
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -526,6 +526,33 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-mock"
+version = "4.0.15"
+description = "Typing stubs for mock"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-requests"
+version = "2.28.0"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.16"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -572,7 +599,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0d9f012b2f35b299dd94b9e0b8e5bbcc8abf74acc0535ad71e0ca9c061043a7a"
+content-hash = "742085528de551b2c2dcc1c742dc6d61f0059cba073fbfe44c9fcfa931bdef33"
 
 [metadata.files]
 atomicwrites = [
@@ -904,6 +931,18 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+types-mock = [
+    {file = "types-mock-4.0.15.tar.gz", hash = "sha256:a849bc2d966063f4946013bf404822ee2b96f77a8dccda4174b70ab61c5293fe"},
+    {file = "types_mock-4.0.15-py3-none-any.whl", hash = "sha256:4535fbb3912b88a247d43cdb41db0c8b2e187138986f6f01a989717e56105848"},
+]
+types-requests = [
+    {file = "types-requests-2.28.0.tar.gz", hash = "sha256:9863d16dfbb3fa55dcda64fa3b989e76e8859033b26c1e1623e30465cfe294d3"},
+    {file = "types_requests-2.28.0-py3-none-any.whl", hash = "sha256:85383b4ef0535f639c3f06c5bbb6494bbf59570c4cd88bbcf540f0b2ac1b49ab"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.16.tar.gz", hash = "sha256:8bb3832c684c30cbed40b96e28bc04703becb2b97d82ac65ba4b968783453b0e"},
+    {file = "types_urllib3-1.26.16-py3-none-any.whl", hash = "sha256:20588c285e5ca336d908d2705994830a83cfb6bda40fc356bbafaf430a262013"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ pytest-cov = "^2.11.1"
 coveralls = "^3.3.1"
 mkdocs-material = "^8.3.9"
 mkdocstrings = "0.19.0"
+types-requests = "^2.28.0"
+types-mock = "^4.0.15"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -91,7 +91,7 @@ class RetrySession(requests.Session):
     def accept_response(self, response: Response, **kwargs: dict) -> bool:
         return response.status_code < 400
 
-    def request(
+    def request(  # type: ignore
         self,
         method: str,
         url: Union[str, bytes, Text],
@@ -127,9 +127,9 @@ class RetrySession(requests.Session):
                     headers=headers,
                     cookies=cookies,
                     files=files,
-                    auth=auth,
+                    auth=auth,  # type: ignore
                     timeout=timeout,
-                    allow_redirects=allow_redirects,
+                    allow_redirects=allow_redirects,  # type: ignore
                     proxies=proxies,
                     hooks=hooks,
                     stream=stream,
@@ -207,7 +207,7 @@ class ThrottledSession(RetrySession):
             self._request_frequency = 0.0
             self._last_request = 0
 
-    def request(
+    def request(  # type: ignore
         self,
         method: str,
         url: Union[str, bytes, Text],
@@ -334,7 +334,7 @@ class CachingSession(ThrottledSession):
         """
         return response.status_code == 200
 
-    def request(
+    def request(  # type: ignore
         self,
         method: str,
         url: Union[str, bytes, Text],
@@ -493,7 +493,7 @@ class Scraper(CachingSession):
 
     @property
     def user_agent(self) -> str:
-        return self.headers["User-Agent"]
+        return str(self.headers["User-Agent"])
 
     @user_agent.setter
     def user_agent(self, value: str) -> None:
@@ -512,7 +512,7 @@ class Scraper(CachingSession):
         elif self.headers.get("Accept-Encoding") == "text/*":
             self.headers["Accept-Encoding"] = "gzip, deflate, compress"
 
-    def request(
+    def request(  # type: ignore
         self,
         method: str,
         url: Union[str, bytes, Text],

--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -539,9 +539,9 @@ class Scraper(CachingSession):
         # for example 'HIGH:!DH:!aNULL' to bypass "dh key too small" error
         # https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small
         if ciphers_list_addition:
-            requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ciphers_list_addition
+            requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ciphers_list_addition  # type: ignore
             try:
-                requests.packages.urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST += ciphers_list_addition
+                requests.packages.urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST += ciphers_list_addition  # type: ignore
             except AttributeError:
                 # no pyopenssl support used / needed / available
                 pass

--- a/scrapelib/tests/test_scraper.py
+++ b/scrapelib/tests/test_scraper.py
@@ -93,7 +93,7 @@ def test_all_parameters_to_requests() -> None:
             "cert": "cert",
             "json": "{}",
         }
-        s.get("https://example.com", **all_params)
+        s.get("https://example.com", **all_params)  # type: ignore
         mocker.assert_called_with(
             "GET",
             "https://example.com",
@@ -259,7 +259,7 @@ def test_retry_404() -> None:
     )
 
     with mock.patch.object(requests.Session, "request", mock_request):
-        resp = s.get("http://dummy/", retry_on_404=True)
+        resp = s.request(method="GET", url="http://dummy/", retry_on_404=True)
     assert mock_request.call_count == 2
     assert resp.status_code == 200
 
@@ -270,13 +270,13 @@ def test_retry_404() -> None:
 
     # retry on 404 true, 4 tries
     with mock.patch.object(requests.Session, "request", mock_request):
-        resp = s.get("http://dummy/", retry_on_404=True)
+        resp = s.request(method="GET", url="http://dummy/", retry_on_404=True)
     assert resp.status_code == 404
     assert mock_request.call_count == 4
 
     # retry on 404 false, just one more try
     with mock.patch.object(requests.Session, "request", mock_request):
-        resp = s.get("http://dummy/", retry_on_404=False)
+        resp = s.request(method="GET", url="http://dummy/")
     assert resp.status_code == 404
     assert mock_request.call_count == 5
 
@@ -287,7 +287,7 @@ def test_retry_ssl() -> None:
     # ensure SSLError is considered fatal even w/ retries
     with mock.patch.object(requests.Session, "request", mock_sslerror):
         with pytest.raises(requests.exceptions.SSLError):
-            s.get("http://dummy/", retry_on_404=True)
+            s.get("http://dummy/")
     assert mock_sslerror.call_count == 1
 
 
@@ -408,7 +408,7 @@ def test_ftp_retries() -> None:
     # retry on
     with mock.patch("scrapelib.urllib_urlopen", mock_urlopen):
         s = Scraper(retry_attempts=2, retry_wait_seconds=0.001)
-        r = s.get("ftp://dummy/", retry_on_404=True)
+        r = s.get("ftp://dummy/")
         assert r.content == b"ftp success!"
     assert mock_urlopen.call_count == 2
 

--- a/scrapelib/tests/test_scraper.py
+++ b/scrapelib/tests/test_scraper.py
@@ -259,7 +259,7 @@ def test_retry_404() -> None:
     )
 
     with mock.patch.object(requests.Session, "request", mock_request):
-        resp = s.request(method="GET", url="http://dummy/", retry_on_404=True)
+        resp = s.get("http://dummy/", retry_on_404=True)
     assert mock_request.call_count == 2
     assert resp.status_code == 200
 
@@ -270,13 +270,13 @@ def test_retry_404() -> None:
 
     # retry on 404 true, 4 tries
     with mock.patch.object(requests.Session, "request", mock_request):
-        resp = s.request(method="GET", url="http://dummy/", retry_on_404=True)
+        resp = s.get("http://dummy/", retry_on_404=True)
     assert resp.status_code == 404
     assert mock_request.call_count == 4
 
     # retry on 404 false, just one more try
     with mock.patch.object(requests.Session, "request", mock_request):
-        resp = s.request(method="GET", url="http://dummy/")
+        resp = s.get("http://dummy/", retry_on_404=False)
     assert resp.status_code == 404
     assert mock_request.call_count == 5
 

--- a/scrapelib/tests/test_scraper.py
+++ b/scrapelib/tests/test_scraper.py
@@ -287,7 +287,7 @@ def test_retry_ssl() -> None:
     # ensure SSLError is considered fatal even w/ retries
     with mock.patch.object(requests.Session, "request", mock_sslerror):
         with pytest.raises(requests.exceptions.SSLError):
-            s.get("http://dummy/")
+            s.get("http://dummy/", retry_on_404=True)
     assert mock_sslerror.call_count == 1
 
 
@@ -408,7 +408,7 @@ def test_ftp_retries() -> None:
     # retry on
     with mock.patch("scrapelib.urllib_urlopen", mock_urlopen):
         s = Scraper(retry_attempts=2, retry_wait_seconds=0.001)
-        r = s.get("ftp://dummy/")
+        r = s.get("ftp://dummy/", retry_on_404=True)
         assert r.content == b"ftp success!"
     assert mock_urlopen.call_count == 2
 


### PR DESCRIPTION
Both `requests` and `openssl` sublibraries aren't being properly parsed by mypy and are causing incorrect failures.