### PR TITLE
no-op close method so that Scraper can be context manager

### DIFF
--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -299,10 +299,10 @@ class FTPAdapter(requests.adapters.BaseAdapter):
             return resp
         except URLError:
             raise FTPError(cast(str, request.url))
-    
-    def close(self):
+
+    def close(self) -> None:
         # needed to use session as context manager
-        pass
+        ...
 
 
 # compose sessions, order matters (cache then throttle then retry)

--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -299,6 +299,10 @@ class FTPAdapter(requests.adapters.BaseAdapter):
             return resp
         except URLError:
             raise FTPError(cast(str, request.url))
+    
+    def close(self):
+        # needed to use session as context manager
+        pass
 
 
 # compose sessions, order matters (cache then throttle then retry)


### PR DESCRIPTION
right now

```python
with scrapelib.Scraper(...) as scraper:
    ...
```

results in a `NotImplemented` error because when the context is exited, the session tries to `close` all the associated adapters and the FTPAdapter does not have the method.
