### PR TITLE
Patch bug in call signature, add pylint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,7 @@ jobs:
       run: poetry run mypy --disallow-untyped-defs scrapelib/
     - name: lint with flake8
       run: poetry run flake8 --show-source --statistics --ignore=E203,E501,W503 scrapelib
+    - name: lint with pylint
+      run: poetry run pylint -E scrapelib
     - name: pytest
       run: poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,14 @@ classifiers=[
 scrapeshell = "scrapelib.__main__:scrapeshell"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7.2,<4.0"
 requests = {extras = ["security"], version = "^2.28.1"}
+urllib3 = "<2"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.961"
 flake8 = "^3.9.0"
+pylint = "^2.17.4"
 mock = "^4.0.3"
 pytest = "^7.1.2"
 pytest-cov = "^2.11.1"

--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -18,6 +18,7 @@ from typing import (
     cast,
 )
 import requests
+import urllib3
 from .cache import (  # noqa
     CacheStorageBase,
     FileCache,
@@ -543,9 +544,9 @@ class Scraper(CachingSession):
         # for example 'HIGH:!DH:!aNULL' to bypass "dh key too small" error
         # https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small
         if ciphers_list_addition:
-            requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ciphers_list_addition  # type: ignore
+            urllib3.util.ssl_.DEFAULT_CIPHERS += ciphers_list_addition  # type: ignore
             try:
-                requests.packages.urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST += ciphers_list_addition  # type: ignore
+                urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST += ciphers_list_addition  # type: ignore  # pylint: disable=no-member
             except AttributeError:
                 # no pyopenssl support used / needed / available
                 pass

--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -390,7 +390,7 @@ class CachingSession(ThrottledSession):
 
         method = method.lower()
 
-        request_key = self.key_for_request(method, url, params)
+        request_key = self.key_for_request(method, url, params=params)
         resp_maybe = None
 
         if request_key and not self.cache_write_only:


### PR DESCRIPTION
## Description

Hi, @jamesturk – Thanks for this most excellent library! We use it all the time at @datamade. 

This PR patches a bug caused by calling `key_for_request` with the wrong signature. It also adds pylint, which will catch this type of error.

Example stack trace prior to this patch from our trusty scraper:

```
Traceback (most recent call last):
  File "/usr/local/bin/pupa", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/__main__.py", line 75, in main
    subcommands[args.subcommand].handle(args, other)
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 334, in handle
    return self.do_handle(args, other, juris)
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 391, in do_handle
    report["scrape"] = self.do_scrape(juris, args, scrapers)
  File "/usr/local/lib/python3.10/site-packages/pupa/cli/commands/update.py", line 215, in do_scrape
    report[scraper_name] = scraper.do_scrape(**scrape_args)
  File "/usr/local/lib/python3.10/site-packages/pupa/scrape/base.py", line 120, in do_scrape
    for obj in self.scrape(**kwargs) or []:
  File "/app/lametro/bills.py", line 204, in scrape
    for matter in matters:
  File "/app/lametro/bills.py", line 166, in matters
    for api_event, _ in event_scraper.events(since_datetime=since_datetime):
  File "/usr/local/lib/python3.10/site-packages/legistar/events.py", line 278, in events
    web_event = self._get_web_event(api_event)
  File "/usr/local/lib/python3.10/site-packages/legistar/events.py", line 381, in _get_web_event
    return self.web_detail(api_event)
  File "/usr/local/lib/python3.10/site-packages/legistar/events.py", line 391, in web_detail
event_page = self._webscraper.lxmlize(insite_url)
  File "/usr/local/lib/python3.10/site-packages/legistar/base.py", line 89, in lxmlize
    response = self.get(url, verify=False)
  File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 600, in get
    return self.request("GET", url, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/scrapelib/__init__.py", line 574, in request
    resp = super().request(
  File "/usr/local/lib/python3.10/site-packages/scrapelib/__init__.py", line 389, in request
    request_key = self.key_for_request(method, url, params)
TypeError: LegistarEventsScraper.key_for_request() takes 3 positional arguments but 4 were given; 27459)
```

Separately, pylint caught an error caused by the release of urllib3 2.0 (see: https://github.com/psf/requests/issues/6443), so I've also capped that dependency.
