### PR TITLE
Pin urllib3 for continued DEFAULT_CIPHERS support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ scrapeshell = "scrapelib.__main__:scrapeshell"
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = {extras = ["security"], version = "^2.28.1"}
+urllib3 = "^1.26"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.961"


### PR DESCRIPTION
## Description

The 2.x series of urllib3 removes the DEFAULT_CIPHERS list this lib relies on. This PR pins urllib3 to 1.26.x, [which will continue to receive security fixes](https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#security-fixes-for-urllib3-v1-26-x).

It's probably desirable to support the 2.x series, but I'll consider that out of scope for this quick fix.

This PR supersedes #221. 😳