### PR TITLE
Short circuit retries if exception's request is accepted

### DIFF
--- a/scrapelib/__init__.py
+++ b/scrapelib/__init__.py
@@ -152,7 +152,12 @@ class RetrySession(requests.Session):
             except Exception as e:
                 if isinstance(e, requests.exceptions.SSLError):
                     raise
+
                 exception_raised = e
+
+                if exception_response := getattr(e, "response", None):
+                    if self.accept_response(exception_response):
+                        break
 
             # if we're going to retry, sleep first
             tries += 1


### PR DESCRIPTION
## Description

Hey, @jamesturk! Thanks for your continued fantastic work on this library.

Sometimes it's desirable to accept a response, even if it's technically an error, and handle it downstream in your scraper code. One example is a 410 - Gone status code. This PR tests whether an exception's associated response is accepted and, if so, short circuits the retry loop.

An alternative approach would be to introduce a `retry_on_410` argument akin to `retry_on_404`, but this approach allows for library users to accept whatever kind of response they want for, well, reasons. 🙃

Let me know what you think! 

### Notes

I noticed CI is failing on main. I've started trying to resolve issues on another branch in our fork (seems like a mix of dependency hell and mypy failures). Please let me know if you'd like to see that PR first.